### PR TITLE
Update LGSL table details when box ip is not equal with server ip

### DIFF
--- a/admin/server.php
+++ b/admin/server.php
@@ -106,6 +106,13 @@ while ($rowsServers = mysql_fetch_assoc($servers))
 	$game = query_fetch_assoc( "SELECT `game` FROM `".DBPREFIX."game` WHERE `gameid` = '".$rowsServers['gameid']."' LIMIT 1" );
 	$group = query_fetch_assoc( "SELECT `name` FROM `".DBPREFIX."group` WHERE `groupid` = '".$rowsServers['groupid']."' LIMIT 1" );
 
+	$lgsldetails = query_fetch_assoc( "SELECT `ip` FROM `".DBPREFIX."lgsl` WHERE `id` = '".$rowsServers['serverid']."' LIMIT 1" );
+	if(!empty($lgsldetails) && !empty($serverIp['ip']) && $lgsldetails['ip'] !== $serverIp['ip'])
+	{
+		query_basic("UPDATE `".DBPREFIX."lgsl` SET `ip` = '".$serverIp['ip']."' WHERE `id` = '".$rowsServers['serverid']."'");
+	}
+
+
 	if ($rowsServers['status'] == 'Active' && $rowsServers['panelstatus'] == 'Started')
 	{
 		//---------------------------------------------------------+


### PR DESCRIPTION
Usually when you add a server it will insert the IP address of the box as server IP address inside the LGSL table. However when you decide to change the IP address of the box later to another one and moved the servers on new IP address the IP addresses inside the LGSL table will stay the old IP addresses. This few lines added here would catch this situation as soon as server.php site gets loaded. However I assume handling this could be improved.